### PR TITLE
Adot wip

### DIFF
--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/adot-config.yaml
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/adot-config.yaml
@@ -1,0 +1,219 @@
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  awsxray:
+    endpoint: 0.0.0.0:2000
+    transport: udp
+  statsd:
+    endpoint: 0.0.0.0:8125
+    aggregation_interval: 60s
+  awsecscontainermetrics:
+
+processors:
+  batch/traces:
+    timeout: 1s
+    send_batch_size: 50
+  batch/metrics:
+    timeout: 60s
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - container.memory.reserved
+          - container.memory.utilized
+          - container.cpu.reserved
+          - container.cpu.utilized
+          - container.network.rate.rx
+          - container.network.rate.tx
+          - container.storage.read_bytes
+          - container.storage.write_bytes
+          - container.duration
+  metricstransform:
+    transforms:
+      - include: container.memory.utilized
+        action: update
+        new_name: MemoryUtilized
+      - include: container.memory.reserved
+        action: update
+        new_name: MemoryReserved
+      - include: container.cpu.utilized
+        action: update
+        new_name: CpuUtilized
+      - include: container.cpu.reserved
+        action: update
+        new_name: CpuReserved
+      - include: container.network.rate.rx
+        action: update
+        new_name: NetworkRxBytes
+      - include: container.network.rate.tx
+        action: update
+        new_name: NetworkTxBytes
+      - include: container.storage.read_bytes
+        action: update
+        new_name: StorageReadBytes
+      - include: container.storage.write_bytes
+        action: update
+        new_name: StorageWriteBytes
+
+  resource:
+    attributes:
+      - key: ClusterName
+        from_attribute: aws.ecs.cluster.name
+        action: insert
+      - key: aws.ecs.cluster.name
+        action: delete
+      - key: ServiceName
+        from_attribute: aws.ecs.service.name
+        action: insert
+      - key: aws.ecs.service.name
+        action: delete
+      - key: TaskId
+        from_attribute: aws.ecs.task.id
+        action: insert
+      - key: aws.ecs.task.id
+        action: delete
+      - key: TaskDefinitionFamily
+        from_attribute: aws.ecs.task.family
+        action: insert
+      - key: aws.ecs.task.family
+        action: delete
+      - key: TaskARN
+        from_attribute: aws.ecs.task.arn
+        action: insert
+      - key: aws.ecs.task.arn
+        action: delete
+      - key: DockerName
+        from_attribute: aws.ecs.docker.name
+        action: insert
+      - key: aws.ecs.docker.name
+        action: delete
+      - key: TaskDefinitionRevision
+        from_attribute: aws.ecs.task.version
+        action: insert
+      - key: aws.ecs.task.version
+        action: delete
+      - key: PullStartedAt
+        from_attribute: aws.ecs.task.pull_started_at
+        action: insert
+      - key: aws.ecs.task.pull_started_at
+        action: delete
+      - key: PullStoppedAt
+        from_attribute: aws.ecs.task.pull_stopped_at
+        action: insert
+      - key: aws.ecs.task.pull_stopped_at
+        action: delete
+      - key: AvailabilityZone
+        from_attribute: cloud.zone
+        action: insert
+      - key: cloud.zone
+        action: delete
+      - key: LaunchType
+        from_attribute: aws.ecs.task.launch_type
+        action: insert
+      - key: aws.ecs.task.launch_type
+        action: delete
+      - key: Region
+        from_attribute: cloud.region
+        action: insert
+      - key: cloud.region
+        action: delete
+      - key: AccountId
+        from_attribute: cloud.account.id
+        action: insert
+      - key: cloud.account.id
+        action: delete
+      - key: DockerId
+        from_attribute: container.id
+        action: insert
+      - key: container.id
+        action: delete
+      - key: ContainerName
+        from_attribute: container.name
+        action: insert
+      - key: container.name
+        action: delete
+      - key: Image
+        from_attribute: container.image.name
+        action: insert
+      - key: container.image.name
+        action: delete
+      - key: ImageId
+        from_attribute: aws.ecs.container.image.id
+        action: insert
+      - key: aws.ecs.container.image.id
+        action: delete
+      - key: ExitCode
+        from_attribute: aws.ecs.container.exit_code
+        action: insert
+      - key: aws.ecs.container.exit_code
+        action: delete
+      - key: CreatedAt
+        from_attribute: aws.ecs.container.created_at
+        action: insert
+      - key: aws.ecs.container.created_at
+        action: delete
+      - key: StartedAt
+        from_attribute: aws.ecs.container.started_at
+        action: insert
+      - key: aws.ecs.container.started_at
+        action: delete
+      - key: FinishedAt
+        from_attribute: aws.ecs.container.finished_at
+        action: insert
+      - key: aws.ecs.container.finished_at
+        action: delete
+      - key: ImageTag
+        from_attribute: container.image.tag
+        action: insert
+      - key: container.image.tag
+        action: delete
+
+exporters:
+  awsxray:
+  awsemf/application:
+    namespace: ECS/AWSOTel/Application
+    log_group_name: '/aws/ecs/application/metrics'
+  awsemf/performance:
+    namespace: {{managed.executionName}}/{{managed.collectionName}}/{{managed.executionId}}
+    log_group_name: '/aws/ecs/containerinsights/{ClusterName}/performance'
+    log_stream_name: '{TaskId}'
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ ClusterName ], [ ClusterName, TaskDefinitionFamily, TaskId, ContainerName ] ]
+        metric_name_selectors:
+          - MemoryUtilized
+          - MemoryReserved
+          - CpuUtilized
+          - CpuReserved
+          - NetworkRxBytes
+          - NetworkTxBytes
+          - StorageReadBytes
+          - StorageWriteBytes
+      - metric_name_selectors: [container.*]
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp,awsxray]
+      processors: [batch/traces]
+      exporters: [awsxray]
+    metrics/application:
+      receivers: [otlp, statsd]
+      processors: [batch/metrics]
+      exporters: [awsemf/application]
+    metrics/performance:
+      receivers: [awsecscontainermetrics ]
+      processors: [filter, metricstransform, resource]
+      exporters: [ awsemf/performance ]
+
+  extensions: [health_check]

--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/default-config.json
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/default-config.json
@@ -1,6 +1,7 @@
 {
     "definitions": {
         "taskName": "{{managed.caseNameUnique}}",
+        "adot_enable": false,
         "cw_auto_create_group": "false",
         "datajet_generator_basic_contentType": "random",
         "datajet_generator_basic_contentRandomValueSet": "alpha-numeric",

--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/task-definition.json
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/task-definition.json
@@ -7,6 +7,81 @@
       "FARGATE"
     ],
     "containerDefinitions": [
+      {{#if definitions.adot_enable}}
+      {
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/aws-otel-EC2",
+            "awslogs-region": "{{config.region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        },
+        "healthCheck": {
+          "command": [ "/healthcheck" ],
+          "interval": 5,
+          "timeout": 6,
+          "retries": 5,
+          "startPeriod": 1
+        },
+        "portMappings": [
+          {
+            "hostPort": 2000,
+            "protocol": "udp",
+            "containerPort": 2000
+          },
+          {
+            "hostPort": 4317,
+            "protocol": "tcp",
+            "containerPort": 4317
+          },
+          {
+            "hostPort": 8125,
+            "protocol": "udp",
+            "containerPort": 8125
+          }
+        ],
+        "command": [
+          "--config=s3://{{managed.s3ResourcesBucket}}.s3.us-west-2.amazonaws.com/{{managed.s3ResourcesPath}}/adot-config.yaml"
+        ],
+        "image": "amazon/aws-otel-collector",
+        "name": "aws-otel-collector"
+      },
+      {
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/aws-otel-EC2",
+            "awslogs-region": "{{config.region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        },
+        "portMappings": [
+          {
+            "hostPort": 8000,
+            "protocol": "tcp",
+            "containerPort": 8000
+          }
+        ],
+        "environment": [
+          {
+            "name": "AWS_XRAY_DAEMON_ADDRESS",
+            "value": "localhost:2000"
+          }
+        ],
+        "image": "public.ecr.aws/aws-otel-test/aws-otel-goxray-sample-app:latest",
+        "essential": false,
+        "name": "aws-otel-emitter",
+        "dependsOn": [
+          {
+            "containerName": "aws-otel-collector",
+            "condition": "START"
+          }
+        ]
+      },
+      {{/if}}
       {
         "name": "fluent-bit",
         "image": "{{definitions.imageAwsForFluentBit}}",


### PR DESCRIPTION
You can enable adot on a golden path test with the following definition in your execution:

```
{
    "executionName":  "myExecution",
    "executeCollections": [
        "ecs-firelens-stability-tests"
    ],
    "definitions": {
        ...
        "adot_enable": true,
        "taskCount": 1
    } 
}

```

WIP Adot Container
Based on: https://github.com/aws-observability/aws-otel-collector/blob/main/config/ecs/container-insights/otel-task-metrics-config.yaml



*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
