### PR TITLE
firelens-stability: remove firelens datajet 1kbps to stdout in s3 tests

### DIFF
--- a/apps/firelens-stability/templates/s3-fargate-v04-05-2023/firelens-datajet.json
+++ b/apps/firelens-stability/templates/s3-fargate-v04-05-2023/firelens-datajet.json
@@ -36,17 +36,15 @@
       "comment": "this stage does nothing, but is used for propper json formatting",
       "generator": {
         "name": "basic",
-        "config": {
-        }
+        "config": {}
       },
       "datajet": {
         "name": "stdout",
-        "config": {
-        }
+        "config": {}
       },
       "stage": {
         "batchRate": 1,
-        "maxBatches": 0
+        "batchLimit": 0
       }
     }
   ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
