### PR TITLE
Stability tests: add script to check results

### DIFF
--- a/apps/firelens-stability/check_results.sh
+++ b/apps/firelens-stability/check_results.sh
@@ -35,14 +35,17 @@ ecs-firelens-stability-tests-s3-sensitivity-s3-use_put_object-on
 if [ -z "${1}" ]
 then
     echo "Usage: check_results.sh {region} {cluster} {execution ID}"
+    exit 1
 fi
 if [ -z "${2}" ]
 then
     echo "Usage: check_results.sh {region} {cluster} {execution ID}"
+    exit 1
 fi
 if [ -z "${3}" ]
 then
     echo "Usage: check_results.sh {region} {cluster} {execution ID}"
+    exit 1
 fi
 
 echo "Cluster: ${2} ${1}"

--- a/apps/firelens-stability/check_results.sh
+++ b/apps/firelens-stability/check_results.sh
@@ -1,0 +1,53 @@
+#  Usage: Check results of firelens release stability tests
+#
+#  $1 = region
+#  $2 = cluster name
+# 
+# output order is the same as in our result table template
+
+
+familys_golden="
+ecs-firelens-stability-tests-golden-path-no-onepod-low-throughput
+ecs-firelens-stability-tests-golden-path-onepod-low-throughput
+ecs-firelens-stability-tests-golden-path-onepod-low-throughput-real
+ecs-firelens-stability-tests-golden-path-no-onepod-high-throughput
+ecs-firelens-stability-tests-golden-path-onepod-high-throughput
+"
+
+familys_s3_stability="
+ecs-firelens-stability-tests-s3-stability-s3-throughput-1mbps
+ecs-firelens-stability-tests-s3-stability-s3-throughput-30mbps
+"
+
+familys_s3_sensitivity="
+ecs-firelens-stability-tests-s3-sensitivity-s3-control
+ecs-firelens-stability-tests-s3-sensitivity-s3-outputPluginCount-10
+ecs-firelens-stability-tests-s3-sensitivity-s3-s3_compression-gzip
+ecs-firelens-stability-tests-s3-sensitivity-s3-s3_key_format-advanced
+ecs-firelens-stability-tests-s3-sensitivity-s3-throughput-10mbps
+ecs-firelens-stability-tests-s3-sensitivity-s3-total_file_size-1M
+ecs-firelens-stability-tests-s3-sensitivity-s3-upload_timeout-1m
+ecs-firelens-stability-tests-s3-sensitivity-s3-use_put_object-on
+"
+
+echo "Cluster: ${2} ${1}"
+
+echo "____GOLDEN PATH____" 
+for task_def in $familys_golden; do
+    running_count=$(aws ecs list-tasks --cluster $2 --region $1  --family $task_def | jq '.taskArns | length')
+    echo "${task_def}: ${running_count}"
+done
+
+
+echo "____S3 stability____"
+for task_def in $familys_s3_stability; do
+    running_count=$(aws ecs list-tasks --cluster $2 --region $1  --family $task_def | jq '.taskArns | length')
+    echo "${task_def}: ${running_count}"
+done
+
+
+echo "____S3 sensitivity____"
+for task_def in $familys_s3_sensitivity; do
+    running_count=$(aws ecs list-tasks --cluster $2 --region $1  --family $task_def | jq '.taskArns | length')
+    echo "${task_def}: ${running_count}"
+done


### PR DESCRIPTION
```
147dda285fd4:firelens-stability wppttt$ bash check_results.sh us-west-2 2_31_11-E-2023-05-11T181755926-nuy7hnAc-ecs-firelens-stability-tests
Cluster: 2_31_11-E-2023-05-11T181755926-nuy7hnAc-ecs-firelens-stability-tests us-west-2
____GOLDEN PATH____
ecs-firelens-stability-tests-golden-path-no-onepod-low-throughput: 40
ecs-firelens-stability-tests-golden-path-onepod-low-throughput: 40
ecs-firelens-stability-tests-golden-path-onepod-low-throughput-real: 5
ecs-firelens-stability-tests-golden-path-no-onepod-high-throughput: 40
ecs-firelens-stability-tests-golden-path-onepod-high-throughput: 40
____S3 stability____
ecs-firelens-stability-tests-s3-stability-s3-throughput-1mbps: 40
ecs-firelens-stability-tests-s3-stability-s3-throughput-30mbps: 40
____S3 sensitivity____
ecs-firelens-stability-tests-s3-sensitivity-s3-control: 5
ecs-firelens-stability-tests-s3-sensitivity-s3-outputPluginCount-10: 5
ecs-firelens-stability-tests-s3-sensitivity-s3-s3_compression-gzip: 5
ecs-firelens-stability-tests-s3-sensitivity-s3-s3_key_format-advanced: 5
ecs-firelens-stability-tests-s3-sensitivity-s3-throughput-10mbps: 5
ecs-firelens-stability-tests-s3-sensitivity-s3-total_file_size-1M: 5
ecs-firelens-stability-tests-s3-sensitivity-s3-upload_timeout-1m: 5
ecs-firelens-stability-tests-s3-sensitivity-s3-use_put_object-on: 5
147dda285fd4:firelens-stability wppttt$ gs
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
