### PR TITLE
Upgrade to Node 18 and AL2023

### DIFF
--- a/apps/mountebank-mock/Dockerfile
+++ b/apps/mountebank-mock/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # ---------- Base ----------
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as base
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 ENV CLIENT_S3_BUCKET set-CLIENT_S3_BUCKET-to_your_s3_bucket
 ENV CLIENT_S3_FILE  set-CLIENT_S3_FILE-to_your_s3_config_filename
@@ -10,14 +10,12 @@ ENV CLIENT_S3_FILE  set-CLIENT_S3_FILE-to_your_s3_config_filename
 # Install Mountebank via Node
 RUN yum upgrade -y
 # RUN yum install -y gcc-c++ make
-RUN curl --silent --location https://rpm.nodesource.com/setup_16.x | bash -
+RUN yum install https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
+RUN yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
-RUN amazon-linux-extras install -y epel && yum install -y libASL --skip-broken
 RUN yum install -y \
       unzip \
-      tar \
-      nodejs \
       openssl
 
 WORKDIR /app


### PR DESCRIPTION
Previously we used Node 16, which is now deprecated/too old. Node 16 is the latest version supported on AL2 due to its usage of GLIBC 2.26. So upgrading Node required upgrading to AL2023.


### Testing

I built the docker image and ran it with Fluent Bit:

```
$ docker run -it  --network host -e  "CLIENT_S3_BUCKET=firenosed-dolphin-bucket" -e "CLIENT_S3_FILE=mountebank.json" mountebank-al-202latest

}info: [https:4545] ::ffff:127.0.0.1:38756 => POST /
info: [https:4545] no predicate match, using default response
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
info: [https:4545] ::ffff:127.0.0.1:38768 => POST /
```

```
$ docker run -it -e "FLB_LOG_LEVEL=debug"  --network host  -v $(pwd):/fluent-bit/etc public.ecr.aws/aws-observability/aws-for-fluent-bit:stable

[2023/09/21 22:09:25] [debug] [upstream] KA connection #44 to 127.0.0.1:4545 is now available
[2023/09/21 22:09:25] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=200
[2023/09/21 22:09:25] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Sent events to TCP_A_3dummy
[2023/09/21 22:09:25] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Sent 1 events to CloudWatch
[2023/09/21 22:09:25] [debug] [out flush] cb_destroy coro_id=10
[2023/09/21 22:09:25] [debug] [task] destroy task=0x7f0a0a7150c0 (task_id=0)
[2023/09/21 22:09:26] [debug] [task] created task=0x7f0a0a7150c0 id=0 OK
[2023/09/21 22:09:26] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] task_id=0 assigned to thread #0
[2023/09/21 22:09:26] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=TCP_A_3dummy, group=segfault_tcp_cloudwatch_3
[2023/09/21 22:09:26] [debug] [input chunk] update output instances with new chunk size diff=26
[2023/09/21 22:09:26] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] cloudwatch:PutLogEvents: events=1, payload=228 bytes
[2023/09/21 22:09:26] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Sending log events to log stream TCP_A_3dummy
[2023/09/21 22:09:26] [debug] [upstream] KA connection #44 to 127.0.0.1:4545 has been assigned (recycled)
[2023/09/21 22:09:26] [debug] [http_client] not using http_proxy for header
[2023/09/21 22:09:26] [debug] [aws_credentials] Requesting credentials from the EC2 provider..
[2023/09/21 22:09:26] [debug] [upstream] KA connection #44 to 127.0.0.1:4545 is now available
[2023/09/21 22:09:26] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=200
[2023/09/21 22:09:26] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Sent events to TCP_A_3dummy
[2023/09/21 22:09:26] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Sent 1 events to CloudWatch
[2023/09/21 22:09:26] [debug] [out flush] cb_destroy coro_id=11
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
