### PR TITLE
fix mock mountebank image build

### DIFF
--- a/apps/mountebank-mock/Dockerfile
+++ b/apps/mountebank-mock/Dockerfile
@@ -8,13 +8,13 @@ ENV CLIENT_S3_BUCKET set-CLIENT_S3_BUCKET-to_your_s3_bucket
 ENV CLIENT_S3_FILE  set-CLIENT_S3_FILE-to_your_s3_config_filename
 
 # Install Mountebank via Node
-RUN yum upgrade -y
-# RUN yum install -y gcc-c++ make
-RUN yum install https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
-RUN yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
+RUN dnf upgrade -y
+# RUN dnf install -y gcc-c++ make
+RUN curl -fsSL https://rpm.nodesource.com/setup_18.x | bash -
+RUN dnf install -y nodejs
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
-RUN yum install -y \
+RUN dnf install -y \
       unzip \
       openssl
 
@@ -46,8 +46,8 @@ RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN rm awscliv2.zip
 
-RUN yum remove unzip -y \
-    && yum clean all \
+RUN dnf remove unzip -y \
+    && dnf clean all \
     && rm -rf /var/cache/yum
 
 WORKDIR /


### PR DESCRIPTION
*Issue* mountebank image build fails with GPG verification failure

*Description of changes:*
This fixes mountebank image build. Currently, `make release` will fail with following GPG verification error -
```
 => CACHED [ 2/24] RUN yum upgrade -y                                                                                                                                                                         0.0s 
 => CACHED [ 3/24] RUN yum install https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y                                                                              0.0s 
 => ERROR [ 4/24] RUN yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1 

1.782 Importing GPG key 0x9B1BE0B4:                                                                                                                                                                                
1.782  Userid     : "NSolid <nsolid-gpg@nodesource.com>"                                                                                                                                                           
1.782  Fingerprint: 6F71 F525 2828 41EE DAF8 51B4 2F59 B5F9 9B1B E0B4                                                                                                                                              
1.782  From       : /etc/pki/rpm-gpg/NODESOURCE-NSOLID-GPG-SIGNING-KEY-EL                                                                                                                                          
1.799 Key imported successfully                                                                                                                                                                                    
2.016 Import of key(s) didn't help, wrong key(s)?                                                                                                                                                                  
2.017 Public key for nodejs-18.20.8-1nodesource.x86_64.rpm is not installed. Failing package is: nodejs-2:18.20.8-1nodesource.x86_64                                                                               
2.017  GPG Keys are configured as: file:///etc/pki/rpm-gpg/NODESOURCE-NSOLID-GPG-SIGNING-KEY-EL                                                                                                                    
2.017 The downloaded packages were saved in cache until the next successful transaction.                                                                                                                           
2.017 You can remove cached packages by executing 'yum clean packages'.                                                                                                                                            
2.027 Error: GPG check FAILED                                                                                                                                                                                      
------
Dockerfile:14
--------------------
  12 |     # RUN yum install -y gcc-c++ make
  13 |     RUN yum install https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
  14 | >>> RUN yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
  15 |     RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
  16 |     RUN chmod +x /bin/gimme
--------------------
ERROR: failed to solve: process "/bin/sh -c yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1" did not complete successfully: exit code: 1
make: *** [Makefile:18: release] Error 1
```

The change picks up solution proposed in this issue to fix this - https://github.com/nodesource/distributions/issues/1747

Verified stability tests work with the built image

Verified the content of https://rpm.nodesource.com/setup_18.x which ensures a node repo is used and performs gpg check, by downloading this file
```
# Repository content for Node.js
NODEJS_REPO_CONTENT="[nodesource-nodejs]
name=Node.js Packages for Linux RPM based distros - $SYS_ARCH
baseurl=https://rpm.nodesource.com/pub_${NODE_VERSION}/nodistro/nodejs/$SYS_ARCH
priority=9
enabled=1
gpgcheck=1
gpgkey=https://rpm.nodesource.com/gpgkey/ns-operations-public.key
module_hotfixes=1"

# Write Node.js repository content
echo "$NODEJS_REPO_CONTENT" | tee /etc/yum.repos.d/nodesource-nodejs.repo > /dev/null

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
