### PR TITLE
Make unzip use -qq to control output

### DIFF
--- a/apps/mountebank-mock/Dockerfile
+++ b/apps/mountebank-mock/Dockerfile
@@ -42,7 +42,7 @@ RUN npm install --production && npm cache clean -f && npm link mountebank
 # Install aws cli for s3 client
 WORKDIR /var/tmp
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
+RUN unzip -qq awscliv2.zip
 RUN ./aws/install
 RUN rm awscliv2.zip
 

--- a/examples/mocks/mountebank/Dockerfile
+++ b/examples/mocks/mountebank/Dockerfile
@@ -35,7 +35,7 @@ EXPOSE 2525
 # Install aws cli for s3 client
 WORKDIR /var/tmp
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
+RUN unzip -qq awscliv2.zip
 RUN ./aws/install
 RUN rm awscliv2.zip
 


### PR DESCRIPTION
*Description of changes:*
When awscli is unzipped it is quite noisy, using `-qq` silences most of the output which is not useful during Docker image build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
