### PR TITLE
feat: Add log rotation to prevent unbounded disk growth

### DIFF
--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/default-config.json
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/default-config.json
@@ -18,6 +18,7 @@
         "debugS3Bucket": "{{managed.s3OutputBucket}}",
         "debugS3KeyPrefix": "{{managed.s3OutputExecutionPath}}/{{managed.caseNameUnique}}",
         "is_datajet_tail_enabled": true,
-        "is_fluent_bit_tail_enabled": true
+        "is_fluent_bit_tail_enabled": true,
+        "datajet_file_max_size_bytes": 104857600
     }
 }

--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/firelens-datajet.json
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/firelens-datajet.json
@@ -50,7 +50,8 @@
         "name": "file",
         "config": {
             "folder": "/var/tmp/data_logs",
-            "filename": "service_log_1.txt"
+            "filename": "service_log",
+            "maxFileSizeBytes": {{definitions.datajet_file_max_size_bytes}}
         }
       },
       "stage": {

--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/fluent-bit.conf
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/fluent-bit.conf
@@ -76,12 +76,13 @@
 [INPUT]
     Name             tail
     Tag              ServiceMetrics
-    Path             /tmp/data_logs/service_log_1.txt
+    Path             /tmp/data_logs/service_log_*.txt
     Exclude_Path     *.gz
     Rotate_Wait      15
     Multiline        On
     Parser_Firstline QueryLogSeparator
     Parser_1         QueryLog
+    DB               /tmp/flb-tail.db
 {{/if}}
     # Important! Every INPUT section's Mem_Buf_Limit must be re-computed when
     # the container memory's limit or the number of of INPUT sections change. If you

--- a/datajets/file-datajet.ts
+++ b/datajets/file-datajet.ts
@@ -12,12 +12,18 @@ interface IDatajetConfig {
     folder: string,
     filename: string,
     logKey: string,
+    maxFileSizeBytes?: number,
+    maxRotatedFiles?: number,
 }
 
 const defaultConfig: IDatajetConfig = {
     folder: "./workspace/tmp",
     filename: "output-logs.log",
-    logKey: "log"
+    logKey: "log",
+    // Rotation is controlled by maxFileSizeBytes — if unset, a single file is written indefinitely (original behaviour).
+    // maxRotatedFiles controls how many rotated files to retain (default 5) and only applies when rotation is active.
+    // For stability tests, these are set via datajet_file_max_size_bytes in
+    // apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/default-config.json
 }
 
 const fileDatajet: IDatajet = {
@@ -25,28 +31,52 @@ const fileDatajet: IDatajet = {
     defaultConfig: defaultConfig,
     createConfiguredDatajet: function (config: IDatajetConfig) {
 
-        const file = path.resolve(`${config.folder}/${config.filename}`);
-        let logStream;
+        let fileIndex = 0;
+        let logStream: fs.WriteStream | null = null;
+
+        const openNextStream = () => {
+            // If rotation is enabled, use numbered files; otherwise use the configured filename as-is
+            const filename = config.maxFileSizeBytes
+                ? `${config.filename}_${++fileIndex}.txt`
+                : config.filename;
+            const file = path.resolve(`${config.folder}/${filename}`);
+            return fs.createWriteStream(file, { flags: 'a' });
+        };
 
         return {
             datajetTemplate: this,
             transmitBatch: async (batch: Array<ILogData>) => {
                 if (!logStream) {
-                    logStream = fs.createWriteStream(file, { flags: 'a' }); /* 27.48 seconds - 27.862 */
+                    logStream = openNextStream();
                 }
-                /* does stringify take too long? */
                 const len = batch.length;
                 for (let i = 0; i < len; ++i) {
                     const log = batch[i];
-                    /* const str = `${log[config.key] ?? "null"}\n`; */
-                    /* log[config.key] ?? "null" */
-
                     logStream.write((config.logKey) ?
-                        `${log[config.logKey] ?? "null"}\n` : /* Elapsed time: 27.48 seconds - 27.41 seconds single string */
+                        `${log[config.logKey] ?? "null"}\n` :
                         ((typeof log === "object") ?
                             `${JSON.stringify(log)}\n` :
                             log ?? "null"));
-                    // fs.writeFileSync(file, , { flag: 'a+' });
+
+                    // Roll to next file mid-batch if size limit reached
+                    if (config.maxFileSizeBytes > 0 && logStream.bytesWritten >= config.maxFileSizeBytes) {
+                        await new Promise<void>((resolve) => logStream.end(resolve));
+                        logStream = openNextStream();
+
+                        // Delete oldest file if we've exceeded maxRotatedFiles
+                        const maxFiles = config.maxRotatedFiles;
+                        if (maxFiles > 0) {
+                            const oldestIndex = fileIndex - maxFiles;
+                            if (oldestIndex >= 1) {
+                                const oldest = path.resolve(`${config.folder}/${config.filename}_${oldestIndex}.txt`);
+                                try {
+                                    if (fs.existsSync(oldest)) fs.unlinkSync(oldest);
+                                } catch (e) {
+                                    console.warn(`Failed to delete rotated file ${oldest}: ${e}`);
+                                }
+                            }
+                        }
+                    }
                 }
                 return true;
             }


### PR DESCRIPTION
## Summary

- Rotate log files sequentially at 100MB, keeping 5 files max (500MB cap).
- Update Fluent Bit tail to glob all rotated files and track offsets via DB.

We observed the unbounded disk growth during stability testing (did not cause test failures) which could have masked issues with fluent-bit's disk usage.

## Testing
Locally ran tests to observe log file generation and rotation using new mechanism

*Description of changes:*
feat: Add log rotation to prevent unbounded disk growth

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
