### PR TITLE
Expand private subnet CIDRs from /24 to /20 for concurrent stability test runs

### DIFF
--- a/apps/test-infrastructure/firelens-stability-infrastructure.yaml
+++ b/apps/test-infrastructure/firelens-stability-infrastructure.yaml
@@ -82,14 +82,14 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: 10.0.3.0/24
+      CidrBlock: 10.0.16.0/20
       AvailabilityZone: !Select [0, !GetAZs '']
 
   PrivateSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: 10.0.4.0/24
+      CidrBlock: 10.0.32.0/20
       AvailabilityZone: !Select [1, !GetAZs '']
 
   # Elastic IPs for NAT Gateways


### PR DESCRIPTION
## Description
Expand private subnet CIDRs from /24 to /20 for concurrent stability test runs
Private subnets expanded from 254 to 4094 usable IPs each to support 3+ concurrent stability test runs (285 Fargate tasks per run).

- PrivateSubnet1: 10.0.3.0/24 -> 10.0.16.0/20
- PrivateSubnet2: 10.0.4.0/24 -> 10.0.32.0/20
- Public subnets unchanged (only host NAT Gateways)

## Testing
Created Cfn changeset and verified only PrivateSubnet1 and PrivateSubnet2 and their respective route table associations are modified

## Note
A follow-up PR will be done to update [task subnets](https://github.com/aws/firelens-datajet/blob/main/apps/firelens-stability/config/collection-config.json#L14) to point to these new subnets once the Cloudformation stack is synthesized

*Issue #, if available:* N/A 

*Description of changes:* enhancement: Expand private subnet CIDRs from /24 to /20 to support concurrent stability test runs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
