### PR TITLE
Update taskVpcSubnets to match expanded private subnet CIDRs

### DIFF
--- a/apps/firelens-stability/config/collection-config.json
+++ b/apps/firelens-stability/config/collection-config.json
@@ -11,7 +11,7 @@
     "config": {
         "region": "us-west-2",
         "taskVpcSubnets": [
-            "subnet-02d856999b481337c","subnet-01570cea46ddb85bc"
+            "subnet-021a3daf3b392c70b","subnet-07816172f904be38f"
         ],
         "taskVpcSecurityGroups": [
             "sg-0bf970ffbe345ade1"


### PR DESCRIPTION
Subnet IDs changed after CloudFormation stack update that expanded private subnets from /24 to /20 for concurrent stability test support.

- subnet-02d856999b481337c -> subnet-021a3daf3b392c70b
- subnet-01570cea46ddb85bc -> subnet-07816172f904be38f

*Issue #, if available:*

*Description of changes:* enhancement: Update taskVpcSubnets to match expanded private subnet CIDRs (follow-up to #164)





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
