### PR TITLE
Add ECS health check to Fluent Bit container

### DIFF
--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/task-definition.json
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/task-definition.json
@@ -144,6 +144,13 @@
         "linuxParameters": {
           "initProcessEnabled": true
         },
+        "healthCheck": {
+          "command": ["CMD-SHELL", "curl -f http://127.0.0.1:2020/api/v1/health || exit 1"],
+          "interval": 30,
+          "timeout": 5,
+          "retries": 3,
+          "startPeriod": 30
+        },
         "dependsOn": [{
           "containerName": "mock",
           "condition": "START"

--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/task-definition.json
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/task-definition.json
@@ -146,9 +146,6 @@
         },
         "healthCheck": {
           "command": ["CMD-SHELL", "curl -f http://127.0.0.1:2020/api/v1/health || exit 1"],
-          "interval": 30,
-          "timeout": 5,
-          "retries": 3,
           "startPeriod": 30
         },
         "dependsOn": [{

--- a/apps/firelens-stability/templates/s3-fargate-v04-05-2023/task-definition.json
+++ b/apps/firelens-stability/templates/s3-fargate-v04-05-2023/task-definition.json
@@ -59,9 +59,6 @@
         },
         "healthCheck": {
           "command": ["CMD-SHELL", "curl -f http://127.0.0.1:2020/api/v1/health || exit 1"],
-          "interval": 30,
-          "timeout": 5,
-          "retries": 3,
           "startPeriod": 30
         }{{#if definitions.is_fluent_bit_tail_enabled}},
         "mountPoints": [

--- a/apps/firelens-stability/templates/s3-fargate-v04-05-2023/task-definition.json
+++ b/apps/firelens-stability/templates/s3-fargate-v04-05-2023/task-definition.json
@@ -56,6 +56,13 @@
             "awslogs-create-group": "true",
             "awslogs-stream-prefix": "{{managed.caseNameUnique}}-fluent-bit"
           }
+        },
+        "healthCheck": {
+          "command": ["CMD-SHELL", "curl -f http://127.0.0.1:2020/api/v1/health || exit 1"],
+          "interval": 30,
+          "timeout": 5,
+          "retries": 3,
+          "startPeriod": 30
         }{{#if definitions.is_fluent_bit_tail_enabled}},
         "mountPoints": [
           {


### PR DESCRIPTION
## Summary

Add ECS container health check to the fluent-bit container in the task definition templates used by the `ecs-firelens-stability-tests` qualification collection. We have seen issues related to http server being deadlocked - https://github.com/fluent/fluent-bit/issues/11769 . While this change does not test or repro the exact same issue, it is a basic sanity check being added.

## Changes

Added to `golden-path-mountebank-fargate-v01-11-2023/task-definition.json` and `s3-fargate-v04-05-2023/task-definition.json`:

```json
"healthCheck": {
  "command": ["CMD-SHELL", "curl -f http://127.0.0.1:2020/api/v1/health || exit 1"],
  "interval": 30,
  "timeout": 5,
  "retries": 3,
  "startPeriod": 30
}
```

These templates are referenced by `ecs-firelens-stability-tests` collection -
- `golden-path/case-config.json` - `golden-path-mountebank-fargate-v01-11-2023`
- `s3-stability/case-config.json` - `s3-fargate-v04-05-2023`
- `s3-sensitivity/case-config.json` - `s3-fargate-v04-05-2023`

## Testing

- Validated end-to-end on ECS Fargate with FireLens init image + S3 config (`HTTP_Server On`) + health check - containers report HEALTHY