### PR TITLE
fix(stability): enable Health_Check for the /api/v1/health container check

### DIFF
--- a/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/fluent-bit.conf
+++ b/apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/fluent-bit.conf
@@ -5,6 +5,7 @@
     HTTP_Server  On
     HTTP_Listen  0.0.0.0
     HTTP_PORT    2020
+    Health_Check On
     Flush        1
     Grace        30
     Log_Level    info

--- a/apps/firelens-stability/templates/s3-fargate-v04-05-2023/fluent-bit.conf
+++ b/apps/firelens-stability/templates/s3-fargate-v04-05-2023/fluent-bit.conf
@@ -5,6 +5,7 @@
     HTTP_Server  On
     HTTP_Listen  0.0.0.0
     HTTP_PORT    2020
+    Health_Check On
     Flush        1
     Grace        30
     Log_Level    info


### PR DESCRIPTION
### What

Enable `Health_Check On` in the `[SERVICE]` block of the two stability templates used by `ecs-firelens-stability-tests`, keeping the `/api/v1/health` container health check from #166 unchanged:

- `apps/firelens-stability/templates/golden-path-mountebank-fargate-v01-11-2023/fluent-bit.conf`
- `apps/firelens-stability/templates/s3-fargate-v04-05-2023/fluent-bit.conf`

### Why

The health check added in #166 uses `curl -f http://127.0.0.1:2020/api/v1/health`, but the stability configs set `HTTP_Server On` without `Health_Check On`. `/api/v1/health` is only registered as a real endpoint when the `Health_Check` feature is enabled. Without it:

- On **FLB 5.0.x** the endpoint **404s** (the root `/` route became exact-match after the upstream
  HTTP server rewrite, [fluent/fluent-bit#11538](https://github.com/fluent/fluent-bit/pull/11538)), so every task reports **UNHEALTHY**.
- On **<= 4.x / 1.9.10** the endpoint isn't registered either, but the old Monkey server's catch-all root returns **200 build-info**, so the check "passes" without actually reporting health.

### Testing

- Confirmed `/api/v1/health` -> `200 ok` on both FLB 1.9.10 and 5.0.9 with `Health_Check On`.
- Ran stability tests (`apps/firelens-stability`) using upstream 5.0.9 and all tasks reported healthy.